### PR TITLE
docs: establish PR-cycle workflow on branch-protected main

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Source of truth for main's branch protection. To re-apply after a break-glass: gh api -X PUT /repos/LPettay/portland-hackathon/branches/main/protection --input .github/branch-protection.json",
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["hygiene"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 0,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false,
+  "required_linear_history": false
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ If a contributor (human or AI) proposes one of these, redirect to the demo scrip
 5. **After substantive edits**, run `bun run check` (the pre-commit hook will too). Fix anything you broke.
 6. **If you make a structural decision** (new directory, new dependency, schema change), append a one-paragraph ADR to `docs/decisions/`.
 7. **Commit messages** follow Conventional Commits (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
+8. **Never commit directly to `main`** — it's branch-protected. Every change goes through a PR (see [CONTRIBUTING.md](./CONTRIBUTING.md#pull-requests)). One feature = one branch = one PR = one squash-merge.
 
 ## Enforcement (you can't lie to the repo)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,57 @@ EOF
 
 ## Pull requests
 
-1. Open against `main`
-2. Use the [PR template](./.github/PULL_REQUEST_TEMPLATE.md)
-3. Self-review your diff before requesting review
-4. Keep PRs small (< 300 lines diff ideal); huge PRs get rejected at the door
-5. **No PR merges without a working `bun dev` confirmed by the author**
+`main` is **branch-protected**. You cannot push directly. Every change goes through this loop:
 
-For 3-hour hackathon cadence: PRs may be reviewed and merged by the author in solo work, but the template still gets filled out so we have a paper trail for the demo.
+```bash
+git switch main && git pull --ff-only         # start from latest main
+git switch -c feat/<short-slug>               # new branch per change
+# ... do the work ...
+bun run check                                 # quick local sanity (pre-commit will too)
+git add . && git commit -m "feat: ..."        # conventional commit
+git push -u origin HEAD                       # push the branch
+gh pr create --fill --web                     # open PR using the template
+# ... wait for CI (~10s) ...
+gh pr merge --squash --delete-branch          # merge once green
+git switch main && git pull --ff-only         # sync local main
+```
+
+### Rules (enforced by GitHub branch protection)
+
+1. **Open against `main`** — direct pushes are blocked
+2. **Use the [PR template](./.github/PULL_REQUEST_TEMPLATE.md)** — `gh pr create --fill` will populate it
+3. **CI must pass** (`hygiene` job: repo checks + typecheck) before merge
+4. **Self-review your diff** before merging — `gh pr diff` or the web UI
+5. **Keep PRs small** (< 300 lines diff ideal); huge PRs get rejected at the door
+6. **Confirm `bun dev` works** for any PR that touches product code
+
+### Solo-merge is allowed
+
+Approval count is set to **0** so solo work isn't blocked, but the PR is still required and CI still gates the merge. The PR template is the paper trail.
+
+### Squash-merge always
+
+We squash-merge so `main` history stays one-commit-per-PR. Conventional Commit titles on the PR become the commit message on `main`.
+
+### Branch naming
+
+| Prefix | Use |
+|---|---|
+| `feat/` | New capability or feature |
+| `fix/` | Bug fix |
+| `docs/` | Docs only |
+| `chore/` | Tooling, config, refactor with no behavior change |
+| `revert/` | Reverting a prior change |
+
+### Emergency bypass
+
+Branch protection has `enforce_admins: true` — there is **no escape hatch.** If you absolutely must commit straight to `main` (broken CI blocking the demo, etc.), the only path is:
+
+1. Temporarily disable protection: `gh api -X DELETE /repos/<owner>/<repo>/branches/main/protection`
+2. Push the fix
+3. **Immediately** re-enable protection (use the JSON in [`.github/branch-protection.json`](./.github/branch-protection.json))
+
+Document why in the commit message. Re-enable before walking away from the keyboard.
 
 ---
 

--- a/docs/decisions/0004-pr-cycle-on-main.md
+++ b/docs/decisions/0004-pr-cycle-on-main.md
@@ -1,0 +1,52 @@
+# ADR 0004: All changes go through PRs against a branch-protected `main`
+
+## Status
+
+Accepted — 2026-04-25
+
+## Context
+
+Five commits already landed on `main` directly (the foundation + enforcement scaffolding). Going forward we want every feature/fix/iteration to follow a clear, repeatable cycle so:
+
+- The demo branch is always reviewable
+- CI gates every change (no commit to `main` without `bun run check` and `bunx tsc --noEmit` passing)
+- The PR template + ADR pattern build an auditable history of decisions
+- A teammate (or judge) reviewing the repo can see the work as a sequence of small, intentional PRs rather than a heap of commits
+
+## Decision
+
+`main` is branch-protected on GitHub with:
+
+- **Required status check:** `hygiene` job (runs on every push and PR)
+- **Required PR before merge:** approval count = 0 (solo-friendly), but the PR is mandatory
+- **`enforce_admins: true`:** owner cannot bypass without explicitly disabling protection
+- **No force pushes, no deletions**
+
+Workflow:
+
+```
+main (protected)
+  ├── feat/<slug>   →  push  →  gh pr create --fill  →  CI green  →  squash-merge
+  ├── fix/<slug>    →  ...                                                  ↑
+  └── docs/<slug>   →  ...                                                  ↑
+                                                                         (history stays
+                                                                          one commit per PR)
+```
+
+The full procedure lives in [`CONTRIBUTING.md`](../../CONTRIBUTING.md#pull-requests). The protection JSON lives in [`.github/branch-protection.json`](../../.github/branch-protection.json) for re-application after any break-glass.
+
+## Consequences
+
+- **Pro:** No more "oops" pushes to `main`. Every change has a PR with a self-review checklist.
+- **Pro:** CI failure surfaces in the PR before merge — `main` stays demo-ready at all times.
+- **Pro:** Squash-merge keeps the `main` history readable as a feature log.
+- **Pro:** Branch protection JSON is version-controlled — settings can't drift unnoticed.
+- **Con:** Extra ~30 seconds per change (push, open PR, wait for CI, merge). Acceptable; CI runs in ~10s.
+- **Con:** Solo dev with `enforce_admins: true` means an emergency bypass requires temporarily disabling protection. Documented in CONTRIBUTING; we accept the friction in exchange for the guarantee.
+
+## Alternatives considered
+
+- **No protection, just convention** — relies on memory. Rejected: we already saw 5 direct commits to `main` before this ADR.
+- **Require approvals (≥1)** — would block solo work entirely. Rejected.
+- **Allow admin bypass (`enforce_admins: false`)** — defeats the point for a solo dev who is the only admin. Rejected.
+- **Rebase-merge instead of squash-merge** — keeps individual commit messages but pollutes `main` history with WIP commits. Rejected for hackathon clarity.


### PR DESCRIPTION
## What

Documents the now-enforced pull-request workflow on `main` (branch protection landed via API just before this PR).

## Why

`main` is branch-protected as of today: PR required, `hygiene` check required, no force pushes, `enforce_admins: true`. The repo needed three things to make that real for contributors and agents:

1. A concrete step-by-step loop in `CONTRIBUTING.md` (gh commands, branch naming, squash-merge policy, break-glass)
2. A line in the root `AGENTS.md` so AI agents see the constraint before they try to push to main
3. The protection settings captured as JSON in `.github/branch-protection.json` so they can be re-applied exactly after any temporary disable
4. An ADR (`0004-pr-cycle-on-main.md`) recording the decision and trade-offs

## Demo impact

- [x] **Internal** — refactor, dev tooling, docs only

## Screenshots / clips

N/A — docs and config only.

## Checklist

- [x] `bun run lint` passes — N/A (no lint configured yet)
- [x] `bun run check` passes (presence + forbidden + freshness)
- [x] `bunx tsc --noEmit` passes
- [x] `bun dev` runs without errors — N/A (no Next.js shell yet)
- [x] Demo flow still works end-to-end — N/A
- [x] Updated relevant `AGENTS.md` (root) to reflect the new constraint
- [x] Logged an ADR in `docs/decisions/` (ADR-0004)

## Out-of-scope reminder

- [x] No auth, no database, no persistence
- [x] No new template beyond the 4-template cap
- [x] No new npm dependency without prior human sign-off

## Notes

This PR is also the **first dogfood of the workflow it documents** — created from a `docs/pr-cycle` branch, will be squash-merged once `hygiene` CI passes. Every subsequent change should follow the same loop.

Made with [Cursor](https://cursor.com)

---

*Backfilled 2026-04-25 (PR #7): collapsed the unselected Demo-impact alternatives per template instructions ("Pick one and delete the others") so the merged history reads as completed work. No content changes.*
