### PR TITLE
chore(pr-template): match real scripts; explicit CI box; worktree note

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
 <!--
 Keep PRs small. Hackathon goal: < 300 lines diff, mergeable in < 5 minutes of review.
+
+Only leave a checkbox in the body if you intend to check it. Delete or rewrite
+items that don't apply rather than shipping the PR with unchecked boxes — they
+read as incomplete tasks.
 -->
 
 ## What
@@ -12,27 +16,34 @@ Keep PRs small. Hackathon goal: < 300 lines diff, mergeable in < 5 minutes of re
 
 ## Demo impact
 
-<!-- Pick one and delete the others -->
+<!-- Pick exactly one and DELETE the other two lines. -->
 - [ ] **Demo path** — directly affects what judges see
 - [ ] **Demo support** — improves reliability/polish but invisible to judges
 - [ ] **Internal** — refactor, dev tooling, docs only
 
 ## Screenshots / clips
 
-<!-- Required for any UI or animation change. Drag-drop a screen recording or PNG. -->
+<!-- Required for any UI or animation change. Drag-drop a screen recording or PNG. Delete this section for non-UI PRs. -->
 
 ## Checklist
 
-- [ ] `bun run lint` passes
+<!--
+Required for every PR. Strike through (~~item~~) or delete any item that's
+genuinely N/A so the remaining boxes are real, checkable tasks.
+-->
+
+- [ ] `bun run check` passes (presence + forbidden + freshness)
 - [ ] `bun run typecheck` passes
-- [ ] `bun dev` runs without errors
-- [ ] Demo flow still works end-to-end (if Demo path or Demo support)
-- [ ] Updated relevant `AGENTS.md` if I changed structure or conventions
+- [ ] CI `hygiene` job is green on this PR — **verify after `gh pr checks --watch`, before `gh pr merge`**
+- [ ] `bun dev` runs without errors (only once the Next.js app exists; delete this line until then)
+- [ ] Demo flow still works end-to-end (only if Demo path or Demo support; delete otherwise)
+- [ ] Updated relevant `AGENTS.md` if I changed structure or conventions in that directory
 - [ ] Logged an ADR in `docs/decisions/` if this was a structural decision
+- [ ] Working in a dedicated worktree (`bun run wt:add`) if any other agent session is active
 
 ## Out-of-scope reminder
 
-<!-- Confirm: this PR does NOT add any of the following -->
+<!-- Confirm: this PR does NOT add any of the following. Leave these checked. -->
 - [ ] No auth, no database, no persistence
 - [ ] No new template beyond the 4-template cap (unless replacing one)
 - [ ] No new npm dependency without prior human sign-off

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "bun run scripts/check.ts",
     "check:agents": "bun run scripts/check.ts --only=presence,freshness",
     "check:fs": "bun run scripts/check.ts --only=forbidden",
+    "typecheck": "bunx tsc --noEmit",
     "agents:stamp": "bun run scripts/stamp.ts",
     "agents:stamp-all": "bun run scripts/stamp.ts --all",
     "agents:stale": "bun run scripts/check.ts --only=freshness --verbose",


### PR DESCRIPTION
## What

Fix the PR template so its checklist references scripts that actually exist and items that are actually verifiable. Add an explicit "CI hygiene green" item to stop PRs from landing with stale unchecked boxes.

## Why

Audit of the first 5 merged PRs found:

- PR #1 had to write `[x] bun run lint passes — N/A (no lint configured yet)` because the template asks for `bun run lint` (not a real script) and `bun dev` (no Next.js app yet).
- PRs #2–#5 each shipped with `[ ] CI hygiene job green on this PR` left unchecked because the box was added at PR-creation time and never re-visited after CI passed. Those PRs read like incomplete work in the merged history.

This patch changes the *template* so future PRs avoid both problems. A separate post-merge cleanup will backfill #1–#5 bodies via `gh pr edit` so the merged history reads as complete.

## Demo impact

- [x] **Internal** — refactor, dev tooling, docs only

## Checklist

- [x] `bun run check` passes (presence + forbidden + freshness)
- [x] `bun run typecheck` passes (new script — `bunx tsc --noEmit` under the hood)
- [x] CI `hygiene` job is green on this PR — verified via `gh pr checks 7` before merge
- [x] Working in a dedicated worktree (`/Users/lance/PortlandHackathon-wt/chore-pr-template-cleanup`) — first dogfood of the wt: tooling for an end-to-end PR cycle
- [x] No new dependency, no lockfile churn

## Out-of-scope reminder

- [x] No auth, no database, no persistence
- [x] No new template beyond the 4-template cap
- [x] No new npm dependency without prior human sign-off

## Follow-up (will be done immediately after merge, no PR needed)

Backfill the unchecked items in PRs #1–#5 via `gh pr edit --body` so the merged-PR history stops looking like abandoned work:

- PR #1: collapse the unselected Demo-impact alternatives, mark every box with its real status
- PR #2–#5: tick the `CI hygiene job green` box (CI passed; branch protection wouldn't have allowed merge otherwise)

Made with [Cursor](https://cursor.com)
