### PR TITLE
docs(preso): pivot deck to "prompt in, cute SVG gif out"

### DIFF
--- a/presentation/AGENTS.md
+++ b/presentation/AGENTS.md
@@ -8,14 +8,29 @@ The judges-handout deck. Self-contained Slidev project; isolated from the main N
 
 | File | Purpose |
 |---|---|
-| `slides.md` | Source of truth — all 3 slides as Markdown + inline SVG |
+| `slides.md` | Source of truth — frontmatter + 3 thin slide shells that mount Vue components |
 | `package.json` | Slidev install + dev/build/export scripts |
 | `README.md` | How to run the deck locally and export to PDF |
 | `.gitignore` | Slidev build artifacts |
 
+### Subdirectories
+
+| Dir | Purpose |
+|---|---|
+| `components/` | One Vue SFC per slide body, plus reusable visuals (`EnforcementChain.vue`) |
+
+#### `components/` files
+
+| File | Purpose |
+|---|---|
+| `Slide1Principles.vue` | Slide 1 — "we built the scaffolding before the product" + 5-layer chain |
+| `Slide2Architecture.vue` | Slide 2 — data flow + stack table |
+| `Slide3Demo.vue` | Slide 3 — "prompt in, cute SVG gif out" + live URL + 3 example outputs |
+| `EnforcementChain.vue` | Reusable visual: the 5-stop enforcement pipeline (used by Slide 1) |
+
 ## What this is
 
-A **3-slide max** Markdown-driven deck (`slides.md`) projected alongside the live demo so judges can understand MotionPitch in 30 seconds without listening to the speaker.
+A **3-slide max** Slidev deck projected alongside the live demo so judges can understand MotionPitch in 30 seconds without listening to the speaker. The deck order leads with **agentic principles**, then the **architecture**, then the **product + live URL** — because for this hackathon the engineering rigor is the differentiator, and the product fits in one sentence.
 
 ## Hard constraints
 
@@ -23,30 +38,52 @@ A **3-slide max** Markdown-driven deck (`slides.md`) projected alongside the liv
 |---|---|
 | Slide count | **Cap at 3.** A judges handout is not a talk deck. If you need a 4th, delete a 1st. |
 | Package manager | `bun` only. |
-| Tooling | Slidev + Tailwind/UnoCSS classes only. No new frameworks. |
-| Source of truth | `slides.md`. Everything else is config. |
+| Tooling | Slidev + Vue SFC components + UnoCSS classes. No new frameworks. |
+| Slide bodies | Each slide body lives in a Vue SFC under `components/`. Slidev's markdown renderer eats nested HTML on blank lines, so we keep `slides.md` thin and let Vue render the rest. |
+| Source of truth | `slides.md` for ordering, frontmatter, and speaker notes. `components/Slide*.vue` for layout + content. |
 | Demo script | This deck must agree with [`../docs/demo-script.md`](../docs/demo-script.md). If they conflict, the demo script wins. |
+
+## Visual identity
+
+| Token | Value |
+|---|---|
+| Background | `#fffbf2` (warm cream) |
+| Ink | `#1c1917` (charcoal) |
+| Accent | `#ea580c` (amber-600) |
+| Accent dark | `#7c2d12` (amber-900) |
+| Surface | `#fef3c7` (amber-100) |
+| Border | `#fde68a` (amber-200) |
+| Serif | `Fraunces` (titles, URL) |
+| Sans  | `Inter` (body) |
+| Mono  | `JetBrains Mono` (eyebrows, code, pills) |
+
+Eyebrow style: 11px JetBrains Mono, uppercase, 2.5px letter-spacing, accent color. Use it once per slide above the H1.
 
 ## Editing rules
 
+- **One Vue SFC per slide body.** Don't try to nest complex HTML inside `slides.md` — markdown-it will mangle it.
 - **Tone:** confident, terse, judge-friendly. Cut anything that needs a sentence to explain.
-- **No internal jargon.** Judges don't know what Zod or App Router is.
+- **No internal jargon.** Judges don't know what Zod or App Router is — but they will see them mentioned, so make sure the *role* is clear from context.
 - **Visuals over prose.** Each slide should read in <10 seconds.
-- **One idea per slide.** If a slide needs a sub-bullet to clarify the headline, the headline is wrong.
+- **One idea per slide.**
+- **Animations must respect `prefers-reduced-motion`.** Every keyframe block in this directory ends with a `@media (prefers-reduced-motion: reduce)` reset.
 
 ## When to update
 
-- Product copy changed in the README → mirror it here.
+- Product copy changed in the README → mirror it on slide 3.
+- Live demo URL changes → update `Slide3Demo.vue`.
 - New top-level capability shipped → only update if it changes the elevator pitch.
 - Demo script changed → reconcile any contradictions immediately.
+- Stack picks change → update the stack table on slide 2.
 
 ## What NOT to do
 
 - Don't add a "team" slide, "thank you" slide, or "Q&A" slide.
-- Don't import images larger than necessary (we want PDF export to stay <2MB).
+- Don't import images (SVG and CSS only — keeps PDF export <2MB).
 - Don't add transitions fancier than `fade` or `slide-left`.
 - Don't bring in a new theme without ADR sign-off.
+- Don't put complex multi-line HTML directly in `slides.md` — promote it to a Vue SFC.
 
 ---
 
-<!-- last-reviewed: a9279ef -->
+<!-- last-reviewed: e21fde4 -->

--- a/presentation/README.md
+++ b/presentation/README.md
@@ -4,9 +4,11 @@ A 3-slide [Slidev](https://sli.dev) deck designed to project alongside the live 
 
 ## Slides
 
-1. **Hook** — what MotionPitch does, in one line + a visual
-2. **The trick** — humans craft the SVG templates, the LLM only picks + customizes
-3. **What's next** — the moat (motion library) and the roadmap
+1. **Principles** — we built the scaffolding before the product (5-layer enforcement, AGENTS.md, ADRs, worktrees)
+2. **Architecture** — data flow + stack table; one API route, one schema, one render path
+3. **Demo** — "prompt in, cute SVG gif out" + live URL + 3 example outputs
+
+The deck leads with principles because, for this hackathon, the engineering rigor is the differentiator. The product fits in one sentence and lives at [motionpitch.vercel.app](https://motionpitch.vercel.app).
 
 ## Run it
 
@@ -26,9 +28,11 @@ bun run export-pdf   # writes slides-export.pdf
 
 ## Edit
 
-The whole deck lives in [`slides.md`](./slides.md). Slidev hot-reloads on save.
+- Slide ordering, frontmatter, and speaker notes live in [`slides.md`](./slides.md).
+- Each slide body lives in a Vue SFC under [`components/`](./components/) — markdown-it can't be trusted to round-trip nested HTML inside a slide block, so we promote slide bodies to components.
+- Style tokens (colors, fonts) are defined per-component using `<style scoped>` and documented in [`AGENTS.md`](./AGENTS.md).
 
-Style tweaks live in the `<style>` block at the top of `slides.md` and use Tailwind/UnoCSS classes inline.
+Slidev hot-reloads on save.
 
 ## Why a separate sub-project?
 

--- a/presentation/components/AGENTS.md
+++ b/presentation/components/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md — `presentation/components/`
+
+Vue Single File Components mounted by the Slidev deck. **Slide bodies live here, not in `slides.md`.**
+
+## Index
+
+### Files here
+
+| File | Purpose |
+|---|---|
+| `Slide1Principles.vue` | Slide 1 body — agentic principles (lead) + 5-layer enforcement chain |
+| `Slide2Architecture.vue` | Slide 2 body — data flow + stack table |
+| `Slide3Demo.vue` | Slide 3 body — product pitch + live URL + 3 cute SVG examples |
+| `EnforcementChain.vue` | Reusable visual: the 5-stop enforcement pipeline (used by Slide 1) |
+
+## Why this directory exists
+
+Slidev parses `slides.md` through markdown-it before handing each slide to Vue. markdown-it has aggressive rules about re-parsing inline HTML — a blank line inside a `<div>` block causes the inner content to be re-interpreted as Markdown and the closing tags to leak out as text. We hit this trying to put complex multi-column layouts directly into `slides.md`.
+
+The fix: each slide body is a Vue SFC. `slides.md` becomes a thin shell of three `<SlideXxx />` mounts plus frontmatter + speaker notes. Slidev auto-imports anything in `components/` (no manual registration needed).
+
+## Conventions
+
+| Rule | Why |
+|---|---|
+| One `.vue` file per slide body, named `Slide{N}{Topic}.vue` | Easy to find. The number matches the slide order in `slides.md`. |
+| Root element is a single `<div class="sX">` (where `X` is the slide number) with `position: absolute; inset: 0;` | Lets the slide fill Slidev's canvas regardless of `layout: none`. |
+| `<style scoped>` only | Prevents bleed across slides. |
+| Visual tokens (color/font) hard-coded per component | Slidev's UnoCSS theme tokens don't reach inside Vue scoped styles reliably. The brand palette is documented in `../AGENTS.md` — copy/paste the hex values; don't try to share via CSS variables across SFCs. |
+| Every keyframe block ends with a `prefers-reduced-motion` reset | Accessibility + judges in motion-sensitive contexts. |
+| No external assets (no `<img>`, no `<image>`, no fonts beyond what `slides.md` declares) | PDF export stays small; deck stays portable. |
+| Reusable visuals (e.g. `EnforcementChain.vue`) live alongside slide bodies, not in a sub-folder | Three slides, one shared component — sub-folders would be premature structure. |
+
+## Adding a slide
+
+1. Decide what the slide *shows* before writing copy. If you can't sketch it in 30 seconds, the idea isn't ready.
+2. Create `Slide{N}{Topic}.vue` with the root `<div class="s{N}">` shell.
+3. In `slides.md`, add a slide separator (`---`) and `<Slide{N}{Topic} />`.
+4. **Delete a slide first** if the deck is at 3 — the cap is hard.
+
+## What does NOT live here
+
+- The actual product templates → `../../src/templates/`
+- Demo script copy → `../../docs/demo-script.md`
+- Slidev config or scripts → `../package.json` and frontmatter in `../slides.md`
+
+---
+
+<!-- last-reviewed: e21fde4 -->

--- a/presentation/components/EnforcementChain.vue
+++ b/presentation/components/EnforcementChain.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+/**
+ * Slide 3 visual: the 5-layer "kept the AI honest" enforcement chain.
+ *
+ * Each layer is a labeled stop along a horizontal pipeline. A token pulses
+ * down the line so the slide reads as a flow, not a static list. This is
+ * the engineering rigor signal — we want judges to register it instantly.
+ */
+
+const layers = [
+  { code: 'AGENTS.md',     when: 'authoring',       what: 'per-dir agent charter' },
+  { code: 'bun run check', when: 'manual',          what: 'presence + freshness'  },
+  { code: 'pre-commit',    when: 'every git commit', what: 'block bad commits'    },
+  { code: 'IDE hook',      when: 'live',            what: 'nudge in Cursor'       },
+  { code: 'CI on main',    when: 'every PR',        what: 'protected backstop'    },
+];
+</script>
+
+<template>
+  <div class="ec-wrap">
+    <div class="ec-rail">
+      <div class="ec-line" />
+      <div class="ec-token" aria-hidden="true" />
+      <div
+        v-for="(layer, i) in layers"
+        :key="layer.code"
+        class="ec-stop"
+        :style="{ left: `calc(${(i / (layers.length - 1)) * 100}% )` }"
+      >
+        <div class="ec-stop-dot" />
+        <div class="ec-stop-label">
+          <div class="ec-stop-num">0{{ i + 1 }}</div>
+          <div class="ec-stop-code">{{ layer.code }}</div>
+          <div class="ec-stop-when">{{ layer.when }}</div>
+          <div class="ec-stop-what">{{ layer.what }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ec-wrap {
+  width: 100%;
+  padding: 22px 28px 24px;
+}
+
+.ec-rail {
+  position: relative;
+  height: 8px;
+  margin: 0 24px 86px;
+}
+
+.ec-line {
+  position: absolute;
+  top: 3px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, #fed7aa 0%, #fb923c 50%, #ea580c 100%);
+  border-radius: 2px;
+}
+
+.ec-token {
+  position: absolute;
+  top: -3px;
+  left: 0;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #ea580c;
+  box-shadow: 0 0 0 4px rgba(234, 88, 12, 0.18);
+  animation: ec-flow 5.5s ease-in-out infinite;
+}
+
+@keyframes ec-flow {
+  0%   { left: 0%;   transform: translateX(0); }
+  90%  { left: 100%; transform: translateX(-100%); }
+  100% { left: 100%; transform: translateX(-100%); opacity: 0; }
+}
+
+.ec-stop {
+  position: absolute;
+  top: -4px;
+  transform: translateX(-50%);
+  width: 120px;
+  text-align: center;
+}
+
+.ec-stop-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid #ea580c;
+  margin: 0 auto;
+}
+
+.ec-stop-label {
+  margin-top: 14px;
+}
+
+.ec-stop-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  color: #ea580c;
+  font-weight: 700;
+}
+
+.ec-stop-code {
+  margin-top: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1c1917;
+}
+
+.ec-stop-when {
+  margin-top: 4px;
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #a8a29e;
+}
+
+.ec-stop-what {
+  margin-top: 6px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #57534e;
+  line-height: 1.35;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ec-token { animation: none; opacity: 0; }
+}
+</style>

--- a/presentation/components/Slide1Principles.vue
+++ b/presentation/components/Slide1Principles.vue
@@ -1,0 +1,173 @@
+<script setup lang="ts">
+/**
+ * Slide 1 — Agentic principles (the lead).
+ *
+ * Built before the product. The 5-layer enforcement chain is the headline;
+ * three columns underneath name the three rules of engagement that made
+ * the AI a teammate instead of a chaos engine.
+ */
+import EnforcementChain from './EnforcementChain.vue';
+</script>
+
+<template>
+  <div class="sp">
+    <div class="sp-eyebrow">Principles &middot; how the agent earned trust</div>
+    <h1 class="sp-h1">
+      We built the <em>scaffolding</em> before the product.
+    </h1>
+    <p class="sp-tag">
+      AI does the typing. Conventions, charters, and checks decide what gets
+      kept. None of these slides exist by accident.
+    </p>
+
+    <EnforcementChain class="sp-chain" />
+
+    <div class="sp-cols">
+      <div class="sp-col">
+        <div class="sp-col-num">01</div>
+        <div class="sp-col-title">Per-directory <code>AGENTS.md</code></div>
+        <div class="sp-col-body">
+          Every folder ships a charter telling the agent what belongs and
+          what doesn't &mdash; and goes <em>stale automatically</em> when the
+          code drifts five files past its last review.
+        </div>
+      </div>
+
+      <div class="sp-col">
+        <div class="sp-col-num">02</div>
+        <div class="sp-col-title">An ADR for every structural decision</div>
+        <div class="sp-col-body">
+          Six short, reviewable records in <code>docs/decisions/</code>.
+          Bun, no-LLM-SVG, slidev sub-project, branch protection, the index
+          convention, worktrees &mdash; all on the record.
+        </div>
+      </div>
+
+      <div class="sp-col">
+        <div class="sp-col-num">03</div>
+        <div class="sp-col-title">One <code>git worktree</code> per agent</div>
+        <div class="sp-col-body">
+          Parallel Cursor sessions get isolated checkouts &mdash; two agents
+          on two branches never trample each other's <code>HEAD</code>.
+          <code>bun run wt:add &lt;branch&gt;</code>.
+        </div>
+      </div>
+    </div>
+
+    <div class="sp-foot">
+      <span><strong>The product is the demo.</strong> The repo is the receipt.</span>
+      <span class="sp-foot-pg">1 &nbsp;/&nbsp; 3</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sp {
+  position: absolute;
+  inset: 0;
+  padding: 32px 56px 50px;
+  background: #fffbf2;
+  color: #1c1917;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.sp-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #ea580c;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.sp-h1 {
+  font-family: 'Fraunces', serif;
+  font-size: 36px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  font-weight: 600;
+  max-width: 22ch;
+}
+.sp-h1 em { font-style: italic; color: #ea580c; }
+
+.sp-tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #57534e;
+  margin: 0;
+  max-width: 65ch;
+}
+
+.sp-chain { margin: 0; flex-shrink: 0; }
+
+.sp-cols {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 28px;
+  margin-top: 4px;
+}
+
+.sp-col {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sp-col-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  color: #ea580c;
+  font-weight: 700;
+}
+
+.sp-col-title {
+  font-family: 'Fraunces', serif;
+  font-size: 17px;
+  font-weight: 600;
+  color: #1c1917;
+  line-height: 1.25;
+}
+
+.sp-col-body {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 1.55;
+  color: #57534e;
+}
+.sp-col-body code,
+.sp-col-title code {
+  font-family: 'JetBrains Mono', monospace;
+  background: #fef3c7;
+  border: 1px solid #fcd9a4;
+  color: #7c2d12;
+  padding: 0 5px;
+  border-radius: 4px;
+  font-size: 0.88em;
+}
+.sp-col-body em { color: #7c2d12; font-style: italic; }
+
+.sp-foot {
+  position: absolute;
+  left: 56px;
+  right: 56px;
+  bottom: 18px;
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #a8a29e;
+}
+.sp-foot strong { color: #1c1917; font-weight: 600; }
+.sp-foot-pg {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+</style>

--- a/presentation/components/Slide2Architecture.vue
+++ b/presentation/components/Slide2Architecture.vue
@@ -1,0 +1,301 @@
+<script setup lang="ts">
+/**
+ * Slide 2 — Architecture & tech stack.
+ *
+ * Left half: the data flow as a vertical pipeline (input → API → LLM → SVG → page).
+ * Right half: the deliberate stack choices, each with a one-line "why."
+ */
+
+const stack = [
+  { layer: 'Runtime',  pick: 'Bun',           why: 'one toolchain for install, run, scripts' },
+  { layer: 'Framework', pick: 'Next.js 15',   why: 'App Router, server components by default' },
+  { layer: 'Lang',     pick: 'TypeScript',    why: 'strict mode; Zod for LLM I/O at the boundary' },
+  { layer: 'Style',    pick: 'Tailwind 4',    why: 'no CSS modules, no design system overhead' },
+  { layer: 'Motion',   pick: 'Framer Motion', why: 'license-clear, declarative, reduced-motion aware' },
+  { layer: 'LLM',      pick: 'OpenAI (JSON)', why: 'structured outputs, schema-bound, retryable' },
+  { layer: 'Deploy',   pick: 'Vercel',        why: 'preview per branch, zero-config Next.js' },
+];
+</script>
+
+<template>
+  <div class="sa">
+    <div class="sa-eyebrow">Architecture &middot; the smallest thing that ships</div>
+    <h1 class="sa-h1">
+      One API route, one schema, one render path.
+    </h1>
+    <p class="sa-tag">
+      Built for a 3-hour window. Every box on the left has a single owner;
+      every choice on the right has a single reason.
+    </p>
+
+    <div class="sa-cols">
+      <div class="sa-col-flow">
+        <div class="sa-col-eyebrow">
+          <span class="sa-num">A</span>
+          Data flow
+        </div>
+
+        <div class="sa-flow">
+          <div class="sa-step">
+            <div class="sa-step-mark">✦</div>
+            <div>
+              <div class="sa-step-title">User input</div>
+              <div class="sa-step-meta"><code>&lt;InputBox/&gt;</code> &middot; one text field</div>
+            </div>
+          </div>
+
+          <div class="sa-step">
+            <div class="sa-step-mark">→</div>
+            <div>
+              <div class="sa-step-title">POST <code>/api/generate</code></div>
+              <div class="sa-step-meta">edge-friendly route handler &middot; server-only</div>
+            </div>
+          </div>
+
+          <div class="sa-step">
+            <div class="sa-step-mark">⌬</div>
+            <div>
+              <div class="sa-step-title">OpenAI &middot; JSON mode</div>
+              <div class="sa-step-meta">prompt &rarr; structured output &middot; bound to <code>GenerationSchema</code></div>
+            </div>
+          </div>
+
+          <div class="sa-step">
+            <div class="sa-step-mark">✓</div>
+            <div>
+              <div class="sa-step-title">Validate with Zod</div>
+              <div class="sa-step-meta">retry on parse failure &middot; never trusts the wire</div>
+            </div>
+          </div>
+
+          <div class="sa-step">
+            <div class="sa-step-mark">★</div>
+            <div>
+              <div class="sa-step-title">Render the SVG gif</div>
+              <div class="sa-step-meta">React server component &middot; CSS-driven loop</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="sa-col-stack">
+        <div class="sa-col-eyebrow">
+          <span class="sa-num">B</span>
+          Stack
+        </div>
+
+        <table class="sa-stack-table">
+          <tbody>
+            <tr v-for="row in stack" :key="row.layer">
+              <td class="sa-layer">{{ row.layer }}</td>
+              <td class="sa-pick">{{ row.pick }}</td>
+              <td class="sa-why">{{ row.why }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="sa-norules">
+          <span class="sa-no">no</span>
+          database &middot; auth &middot; cache &middot; analytics &middot; image gen
+        </div>
+      </div>
+    </div>
+
+    <div class="sa-foot">
+      <span><strong>One feature &middot; one branch &middot; one PR &middot; one squash.</strong> CI gates every merge to main.</span>
+      <span class="sa-foot-pg">2 &nbsp;/&nbsp; 3</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sa {
+  position: absolute;
+  inset: 0;
+  padding: 32px 56px 56px;
+  background: #fffbf2;
+  color: #1c1917;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sa-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #ea580c;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.sa-h1 {
+  font-family: 'Fraunces', serif;
+  font-size: 32px;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+
+.sa-tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #57534e;
+  margin: 0;
+  max-width: 65ch;
+}
+
+.sa-cols {
+  display: grid;
+  grid-template-columns: 1fr 1.05fr;
+  gap: 36px;
+  margin-top: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+.sa-col-eyebrow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: 'Fraunces', serif;
+  font-size: 18px;
+  font-weight: 600;
+  color: #1c1917;
+  margin-bottom: 10px;
+}
+.sa-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  color: #ea580c;
+  font-weight: 700;
+}
+
+/* flow */
+.sa-flow {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.sa-step {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: center;
+  background: #ffffff;
+  border: 1px solid #fde68a;
+  border-radius: 8px;
+  padding: 8px 12px;
+  box-shadow: 0 1px 2px rgba(124, 45, 18, 0.04);
+}
+.sa-step-mark {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: #fef3c7;
+  border: 1px solid #fcd9a4;
+  color: #ea580c;
+  display: grid;
+  place-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 600;
+}
+.sa-step-title {
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  color: #1c1917;
+}
+.sa-step-meta {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #78716c;
+  margin-top: 2px;
+}
+.sa-step-meta code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.92em;
+  background: #fef3c7;
+  border: 1px solid #fcd9a4;
+  color: #7c2d12;
+  padding: 0 4px;
+  border-radius: 3px;
+}
+
+/* stack table */
+.sa-stack-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+}
+.sa-stack-table tr {
+  border-bottom: 1px dashed #fde68a;
+}
+.sa-stack-table tr:last-child { border-bottom: none; }
+.sa-stack-table td {
+  padding: 7px 0;
+  vertical-align: top;
+}
+.sa-layer {
+  width: 70px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  color: #a8a29e;
+  padding-top: 9px !important;
+}
+.sa-pick {
+  width: 110px;
+  font-weight: 600;
+  color: #1c1917;
+}
+.sa-why {
+  color: #57534e;
+  line-height: 1.5;
+}
+
+.sa-norules {
+  margin-top: 14px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #78716c;
+  background: #fef3c7;
+  border: 1px dashed #fcd9a4;
+  padding: 8px 12px;
+  border-radius: 8px;
+}
+.sa-no {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 1.5px;
+  color: #ea580c;
+  text-transform: uppercase;
+  margin-right: 6px;
+  font-weight: 700;
+}
+
+.sa-foot {
+  position: absolute;
+  left: 56px;
+  right: 56px;
+  bottom: 18px;
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #a8a29e;
+}
+.sa-foot strong { color: #1c1917; font-weight: 600; }
+.sa-foot-pg {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+</style>

--- a/presentation/components/Slide3Demo.vue
+++ b/presentation/components/Slide3Demo.vue
@@ -1,0 +1,326 @@
+<script setup lang="ts">
+/**
+ * Slide 3 — The product + the live link.
+ *
+ * Closes the deck with what MotionPitch actually does: prompt in, cute
+ * SVG gif out. Three illustrative outputs sit beside the URL the judges
+ * should open on their phones.
+ */
+</script>
+
+<template>
+  <div class="sd">
+    <div class="sd-eyebrow">The product &middot; what comes out</div>
+    <h1 class="sd-h1">
+      Prompt in. <em>Cute SVG gif</em> out.
+    </h1>
+    <p class="sd-tag">
+      One sentence describing a vibe, person, or thing. Ten seconds later you
+      get a looping, hand-feeling SVG you can drop into Slack, a slide, a
+      sticker sheet, or a 404 page.
+    </p>
+
+    <div class="sd-cols">
+      <div class="sd-gallery">
+        <div class="sd-card sd-card-1">
+          <svg viewBox="0 0 160 120" class="sd-svg">
+            <rect width="160" height="120" fill="#fef3c7" />
+            <g class="sd-cat">
+              <ellipse cx="80" cy="78" rx="32" ry="24" fill="#1c1917" />
+              <circle cx="80" cy="50" r="22" fill="#1c1917" />
+              <polygon points="64,38 60,22 74,32" fill="#1c1917" />
+              <polygon points="96,38 100,22 86,32" fill="#1c1917" />
+              <circle cx="73" cy="50" r="3" fill="#fef3c7" />
+              <circle cx="87" cy="50" r="3" fill="#fef3c7" />
+              <path d="M 76 58 Q 80 62 84 58" stroke="#fef3c7" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+              <path class="sd-tail" d="M 110 88 q 18 -4 18 -22 q 0 -10 -8 -10" stroke="#1c1917" stroke-width="6" fill="none" stroke-linecap="round" />
+            </g>
+          </svg>
+          <div class="sd-cap">
+            <span class="sd-prompt">"a sleepy cat in a coffee shop"</span>
+          </div>
+        </div>
+
+        <div class="sd-card sd-card-2">
+          <svg viewBox="0 0 160 120" class="sd-svg">
+            <rect width="160" height="120" fill="#ecfccb" />
+            <g class="sd-rocket">
+              <polygon points="80,30 92,76 68,76" fill="#fafaf9" stroke="#3f6212" stroke-width="2" />
+              <polygon points="80,30 92,76 80,72" fill="#d9f99d" />
+              <circle cx="80" cy="56" r="4" fill="#3f6212" />
+              <polygon points="68,76 60,90 72,82" fill="#84cc16" />
+              <polygon points="92,76 100,90 88,82" fill="#84cc16" />
+              <g class="sd-flame">
+                <polygon points="74,82 80,100 86,82" fill="#fb923c" />
+                <polygon points="76,82 80,94 84,82" fill="#fef3c7" />
+              </g>
+              <g class="sd-stars" fill="#3f6212">
+                <circle cx="30" cy="30" r="1.5" />
+                <circle cx="130" cy="42" r="1" />
+                <circle cx="22" cy="80" r="1" />
+                <circle cx="138" cy="92" r="1.5" />
+              </g>
+            </g>
+          </svg>
+          <div class="sd-cap">
+            <span class="sd-prompt">"a tiny rocket about to launch"</span>
+          </div>
+        </div>
+
+        <div class="sd-card sd-card-3">
+          <svg viewBox="0 0 160 120" class="sd-svg">
+            <rect width="160" height="120" fill="#fce7f3" />
+            <g class="sd-ghost">
+              <path d="M 60 36 Q 60 18 80 18 Q 100 18 100 36 L 100 90 L 90 82 L 80 90 L 70 82 L 60 90 Z" fill="#fafaf9" stroke="#9d174d" stroke-width="2" />
+              <circle cx="74" cy="48" r="3" fill="#9d174d" />
+              <circle cx="86" cy="48" r="3" fill="#9d174d" />
+              <ellipse cx="80" cy="60" rx="6" ry="3" fill="#9d174d" />
+              <circle class="sd-blush" cx="68" cy="58" r="3" fill="#fb7185" opacity="0.7" />
+              <circle class="sd-blush" cx="92" cy="58" r="3" fill="#fb7185" opacity="0.7" />
+            </g>
+          </svg>
+          <div class="sd-cap">
+            <span class="sd-prompt">"a friendly ghost saying hi"</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sd-cta">
+        <div class="sd-cta-eyebrow">Try it</div>
+        <div class="sd-url">motionpitch.vercel.app</div>
+        <div class="sd-cta-tag">
+          One input box. No login. Refresh for a new vibe.
+        </div>
+
+        <div class="sd-meta">
+          <div class="sd-meta-row">
+            <span class="sd-meta-k">repo</span>
+            <span class="sd-meta-v">github.com/LPettay/portland-hackathon</span>
+          </div>
+          <div class="sd-meta-row">
+            <span class="sd-meta-k">built</span>
+            <span class="sd-meta-v">3-hour sprint &middot; Cursor + Claude + GPT</span>
+          </div>
+          <div class="sd-meta-row">
+            <span class="sd-meta-k">stack</span>
+            <span class="sd-meta-v">Bun &middot; Next.js 15 &middot; Tailwind &middot; Framer Motion</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sd-foot">
+      <span><strong>Thanks for judging.</strong> Open the URL on your phone &mdash; the gifs loop forever.</span>
+      <span class="sd-foot-pg">3 &nbsp;/&nbsp; 3</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.sd {
+  position: absolute;
+  inset: 0;
+  padding: 36px 56px 56px;
+  background: #fffbf2;
+  color: #1c1917;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sd-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #ea580c;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.sd-h1 {
+  font-family: 'Fraunces', serif;
+  font-size: 40px;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+.sd-h1 em { color: #ea580c; font-style: italic; }
+
+.sd-tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: #57534e;
+  margin: 0;
+  max-width: 64ch;
+}
+
+.sd-cols {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 36px;
+  margin-top: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
+/* gallery */
+.sd-gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  align-content: start;
+}
+.sd-card {
+  background: #ffffff;
+  border: 1px solid #fde68a;
+  border-radius: 10px;
+  padding: 8px;
+  box-shadow: 0 4px 14px -8px rgba(124, 45, 18, 0.18);
+}
+.sd-svg {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  display: block;
+}
+.sd-cap {
+  margin-top: 6px;
+  padding: 0 2px 2px;
+}
+.sd-prompt {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: #7c2d12;
+}
+
+/* card animations */
+.sd-tail {
+  transform-origin: 110px 88px;
+  animation: sd-tail-wag 1.6s ease-in-out infinite;
+}
+@keyframes sd-tail-wag {
+  0%, 100% { transform: rotate(-8deg); }
+  50%      { transform: rotate(8deg); }
+}
+
+.sd-flame {
+  transform-origin: 80px 82px;
+  animation: sd-flame-pulse 0.4s steps(2, end) infinite;
+}
+@keyframes sd-flame-pulse {
+  0%, 50%   { transform: scaleY(1) translateY(0); }
+  51%, 100% { transform: scaleY(0.7) translateY(-1px); }
+}
+.sd-stars circle {
+  animation: sd-twinkle 1.6s ease-in-out infinite;
+}
+.sd-stars circle:nth-child(1) { animation-delay: 0s; }
+.sd-stars circle:nth-child(2) { animation-delay: 0.4s; }
+.sd-stars circle:nth-child(3) { animation-delay: 0.8s; }
+.sd-stars circle:nth-child(4) { animation-delay: 1.2s; }
+@keyframes sd-twinkle {
+  0%, 100% { opacity: 0.2; transform: scale(0.8); transform-origin: center; }
+  50%      { opacity: 1;   transform: scale(1.1); }
+}
+
+.sd-ghost {
+  animation: sd-float 3s ease-in-out infinite;
+}
+@keyframes sd-float {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-4px); }
+}
+.sd-blush { animation: sd-blush-pulse 2.5s ease-in-out infinite; }
+@keyframes sd-blush-pulse {
+  0%, 100% { opacity: 0.4; }
+  50%      { opacity: 0.85; }
+}
+
+/* CTA column */
+.sd-cta {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  background: linear-gradient(135deg, #fef3c7 0%, #fed7aa 100%);
+  border: 1px solid #fcd9a4;
+  border-radius: 14px;
+  padding: 24px 28px;
+  box-shadow: 0 12px 28px -16px rgba(124, 45, 18, 0.35);
+}
+.sd-cta-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 2.5px;
+  text-transform: uppercase;
+  color: #ea580c;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.sd-url {
+  font-family: 'Fraunces', serif;
+  font-size: 26px;
+  font-weight: 600;
+  color: #1c1917;
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  line-height: 1.05;
+}
+.sd-cta-tag {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: #7c2d12;
+  margin-top: 8px;
+}
+
+.sd-meta {
+  margin-top: 18px;
+  border-top: 1px dashed #fcd9a4;
+  padding-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+}
+.sd-meta-row {
+  display: grid;
+  grid-template-columns: 50px 1fr;
+  gap: 8px;
+  color: #57534e;
+}
+.sd-meta-k {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: #a8a29e;
+  padding-top: 1px;
+}
+.sd-meta-v code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.92em;
+  color: #7c2d12;
+}
+
+.sd-foot {
+  position: absolute;
+  left: 56px;
+  right: 56px;
+  bottom: 18px;
+  display: flex;
+  justify-content: space-between;
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: #a8a29e;
+}
+.sd-foot strong { color: #1c1917; font-weight: 600; }
+.sd-foot-pg {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+}
+</style>

--- a/presentation/slides.md
+++ b/presentation/slides.md
@@ -3,203 +3,55 @@ theme: seriph
 title: MotionPitch
 info: |
   ## MotionPitch
-  Type a business. Get a landing page where the hero is custom motion design.
-
-  Cursor Portland Hackathon · Apr 25 2026
-class: text-center
+  Prompt in. Cute SVG gif out. Cursor Portland Hackathon · Apr 25 2026.
 transition: fade
 mdc: true
+colorSchema: light
 fonts:
   sans: 'Inter'
   serif: 'Fraunces'
   mono: 'JetBrains Mono'
+themeConfig:
+  primary: '#ea580c'
+layout: none
 ---
 
 <style>
-  .slidev-layout h1 { font-family: 'Fraunces', serif; }
-
-  /* --- continuous loops; freeze in PDF without looking broken --- */
-  .mp-orbit       { animation: mp-orbit 6s linear infinite; transform-origin: 280px 160px; }
-  .mp-breathe     { animation: mp-breathe 4s ease-in-out infinite; transform-origin: 280px 160px; }
-  .mp-draw        { stroke-dasharray: 220; stroke-dashoffset: 220; animation: mp-draw 4s ease-in-out infinite alternate; }
-  .mp-arrow       { animation: mp-arrow 1.8s ease-in-out infinite; }
-
-  @keyframes mp-orbit   { to   { transform: rotate(360deg); } }
-  @keyframes mp-breathe { 0%,100% { transform: scale(1); } 50% { transform: scale(1.04); } }
-  @keyframes mp-draw    { to   { stroke-dashoffset: 0; } }
-  @keyframes mp-arrow   { 0%,100% { transform: translateX(0); opacity: .7; } 50% { transform: translateX(6px); opacity: 1; } }
+  :root { --slidev-theme-primary: #ea580c; }
+  .slidev-layout { background: #fffbf2 !important; padding: 0 !important; }
 </style>
 
-# MotionPitch
+<Slide1Principles />
 
-<div class="text-xl mt-4 opacity-80">
-  Type a business in one sentence.<br/>
-  Get a landing page whose hero is a <em>custom motion scene</em>.
-</div>
-
-<div class="flex justify-center mt-8">
-  <svg viewBox="0 0 560 320" width="560" height="320" role="img" aria-label="Animated landing page preview">
-    <defs>
-      <linearGradient id="mp-hero-bg" x1="0" y1="0" x2="1" y2="1">
-        <stop offset="0%"  stop-color="#fef3c7"/>
-        <stop offset="100%" stop-color="#fcd9a4"/>
-      </linearGradient>
-      <filter id="mp-shadow" x="-10%" y="-10%" width="120%" height="120%">
-        <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#000" flood-opacity="0.08"/>
-      </filter>
-    </defs>
-
-    <!-- browser frame -->
-    <g filter="url(#mp-shadow)">
-      <rect x="20" y="20" width="520" height="280" rx="14" fill="#ffffff" stroke="#e7e5e4"/>
-      <rect x="20" y="20" width="520" height="32" rx="14" fill="#f5f5f4"/>
-      <circle cx="40" cy="36" r="5" fill="#fca5a5"/>
-      <circle cx="58" cy="36" r="5" fill="#fcd34d"/>
-      <circle cx="76" cy="36" r="5" fill="#86efac"/>
-    </g>
-
-    <!-- left column: stylized page copy -->
-    <g fill="#e7e5e4">
-      <rect x="44" y="76"  width="180" height="14" rx="4"/>
-      <rect x="44" y="100" width="140" height="8"  rx="4"/>
-      <rect x="44" y="116" width="160" height="8"  rx="4"/>
-      <rect x="44" y="132" width="120" height="8"  rx="4"/>
-    </g>
-    <rect x="44" y="170" width="100" height="28" rx="14" fill="#7c2d12"/>
-    <text x="94" y="188" text-anchor="middle" font-size="11" font-family="Inter, sans-serif" fill="#fff">Find a cafe</text>
-
-    <!-- right column: animated hero zone -->
-    <g class="mp-breathe">
-      <rect x="260" y="76" width="240" height="180" rx="12" fill="url(#mp-hero-bg)"/>
-      <!-- coffee-bean-ish silhouette, draws in and out on loop -->
-      <path
-        class="mp-draw"
-        d="M 340 130 C 360 110, 400 110, 420 140 C 440 170, 410 200, 380 200 C 350 200, 330 180, 340 130 Z"
-        fill="none" stroke="#7c2d12" stroke-width="3" stroke-linecap="round"/>
-      <path
-        class="mp-draw"
-        d="M 360 140 C 375 155, 395 165, 408 180"
-        fill="none" stroke="#7c2d12" stroke-width="2.5" stroke-linecap="round" style="animation-delay: .4s"/>
-    </g>
-
-    <!-- orbiting accent dot — the always-moving signal -->
-    <g class="mp-orbit">
-      <circle cx="500" cy="160" r="5" fill="#ea580c"/>
-    </g>
-  </svg>
-</div>
-
-<div class="text-center mt-4 text-sm opacity-60">
-  <span class="font-mono">"Stumptown roastery in Portland"</span>
-  &nbsp;<span class="mp-arrow inline-block">→</span>&nbsp;
-  this, in ~10 seconds
-</div>
-
-<div class="abs-bl mx-14 my-8 text-xs opacity-60">
-  The website is the wrapper.<br/>
-  <strong>The animated SVG hero is the product.</strong>
-</div>
-
-<div class="abs-br mx-14 my-8 text-xs opacity-60">
-  Cursor Portland Hackathon · Apr 25 2026
-</div>
+<!--
+Lead with the principles. Judges should leave knowing we built scaffolding
+before product: AGENTS.md per directory, ADRs for every decision, one git
+worktree per parallel agent, and a 5-layer enforcement chain that fails
+PRs that would weaken any of it.
+-->
 
 ---
-layout: two-cols-header
-class: pt-8
+layout: none
 ---
 
-# The trick
+<Slide2Architecture />
 
-LLMs are bad at SVG. So we don't ask them to make any.
-
-::left::
-
-### Human craft <span class="opacity-60 text-base">(the moat)</span>
-
-A small library of hand-authored, parameterized SVG motion templates.
-
-- 4 templates for the demo
-- Each one looped, branded, polished
-- Adding a template is a creative act, not a prompt
-
-```
-src/templates/
-  ├── coffee-shop.tsx
-  ├── yoga-studio.tsx
-  ├── game-studio.tsx
-  └── generic-service.tsx
-```
-
-::right::
-
-### AI selection <span class="opacity-60 text-base">(the customization)</span>
-
-The LLM only emits structured JSON — never raw SVG.
-
-```json
-{
-  "templateId": "coffee-shop",
-  "palette":    "warm-roast",
-  "copy": {
-    "title":    "Stumptown",
-    "tagline":  "Portland-roasted, daily.",
-    "cta":      "Find a cafe"
-  },
-  "iconKey":    "bean"
-}
-```
-
-<div class="mt-4 text-sm opacity-70">
-  Validated against a fixed schema. Failure mode is "wrong template,"
-  which still looks good.
-</div>
+<!--
+Why this stack: Bun (one toolchain), Next.js 15 App Router (server-by-default),
+Tailwind 4 (no design system overhead), Framer Motion (license-clear),
+OpenAI structured outputs (schema-bound, never raw SVG). Single API route
+keeps surface area trivial for a 3-hour build. PR-cycle on protected main.
+-->
 
 ---
-layout: default
-class: pt-10
+layout: none
 ---
 
-# How we kept the AI honest
+<Slide3Demo />
 
-<div class="text-lg mt-2 opacity-80 max-w-3xl">
-  The AI built the product. The scaffolding made sure it built <em>this</em> product.
-</div>
-
-<div class="mt-10 space-y-7 max-w-4xl">
-  <div class="flex gap-4">
-    <div class="text-emerald-700 text-2xl leading-none mt-1">✓</div>
-    <div>
-      <div class="text-xl font-semibold">5 enforcement layers stop bad commits before they land</div>
-      <div class="font-mono text-sm opacity-70 mt-1">
-        AGENTS.md &nbsp;→&nbsp; bun run check &nbsp;→&nbsp; pre-commit &nbsp;→&nbsp; IDE hook &nbsp;→&nbsp; CI on protected main
-      </div>
-    </div>
-  </div>
-
-  <div class="flex gap-4">
-    <div class="text-emerald-700 text-2xl leading-none mt-1">✓</div>
-    <div>
-      <div class="text-xl font-semibold">Per-directory <span class="font-mono">AGENTS.md</span> charters</div>
-      <div class="text-sm opacity-70 mt-1">
-        Every folder tells the agent what belongs and what doesn't —
-        and goes stale automatically if the code drifts past it.
-      </div>
-    </div>
-  </div>
-
-  <div class="flex gap-4">
-    <div class="text-emerald-700 text-2xl leading-none mt-1">✓</div>
-    <div>
-      <div class="text-xl font-semibold">Every structural decision has an ADR</div>
-      <div class="text-sm opacity-70 mt-1">
-        A short, reviewable record in <span class="font-mono">docs/decisions/</span>.
-        No unexplained choices in the repo.
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="abs-br mx-14 my-8 text-xs opacity-60">
-  Cursor Portland Hackathon · Apr 25 2026
-</div>
+<!--
+Land on the product and the URL. Read the prompt, point at the gif, point at
+the URL. The three example outputs each run a different motion idiom (tail
+wag, flame flicker, gentle float) so judges see range without us listing
+features. End on the invitation: open the URL on your phone.
+-->


### PR DESCRIPTION
## Summary

- Pivots the judges-handout deck to match the new product framing — "prompt in, cute SVG gif out" — while leading with agentic principles, since the engineering scaffolding is the differentiator for this hackathon.
- Slide order is now: **(1) Principles** → **(2) Architecture** → **(3) Demo + live URL**. 3-slide cap preserved.
- Promotes each slide body to a scoped Vue SFC under `presentation/components/`. Slidev's markdown-it pipeline mangles nested HTML on blank lines inside a slide block; this puts the layout in real components and keeps `slides.md` a thin shell of frontmatter + 3 mounts + speaker notes.
- Slide 3 advertises [motionpitch.vercel.app](https://motionpitch.vercel.app) and shows three illustrative cute-SVG outputs (sleepy cat, tiny rocket, friendly ghost), each running a different motion idiom (tail wag, flame flicker, gentle float) so the "range" of the product reads visually.

### What's in `presentation/components/`

| File | Role |
|---|---|
| `Slide1Principles.vue` | Slide 1 body — "we built the scaffolding before the product" + 5-layer enforcement chain |
| `Slide2Architecture.vue` | Slide 2 body — data flow + stack table |
| `Slide3Demo.vue` | Slide 3 body — pitch + live URL + 3 cute SVG examples |
| `EnforcementChain.vue` | Reusable visual: the 5-stop enforcement pipeline (used by Slide 1) |
| `AGENTS.md` | Charter for the new directory |

### Visual identity

Locked in light mode (`colorSchema: light`) with a warm cream background (`#fffbf2`), charcoal ink, amber-600 accent, Fraunces serif for titles, Inter for body, JetBrains Mono for eyebrows + code. Documented in `presentation/AGENTS.md` and `presentation/components/AGENTS.md`.

### Why this approach

`mdc: true` Markdown Components mode lets us mount Vue components inline in `slides.md`, but blank lines inside a raw HTML block cause markdown-it to drop back into Markdown parsing and the closing `</div>` tags leak as text. Promoting each slide body to a Vue SFC sidesteps the issue entirely and gives each slide its own scoped CSS.

## Test plan

- [x] `bun run check` passes (presence, forbidden, freshness)
- [x] All 3 slides render at `bun dev` without console errors
- [x] Animations loop seamlessly (steam wasn't kept; chain token, tail wag, flame flicker, ghost float, twinkles all loop)
- [x] Light mode is locked; black-bar letterboxing in screenshots is just viewport aspect mismatch, not a slide issue
- [ ] PDF export is clean (`bun run export-pdf` — needs Chromium, will verify on a machine that has it)
- [ ] Live URL on slide 3 still resolves


Made with [Cursor](https://cursor.com)